### PR TITLE
Add meal amount 0 checking

### DIFF
--- a/src/main/java/com/gmail/kurumi78/bush/events/BushClick.java
+++ b/src/main/java/com/gmail/kurumi78/bush/events/BushClick.java
@@ -28,8 +28,12 @@ public class BushClick implements Listener {
                     }
                     if (!event.getPlayer().getGameMode().equals(GameMode.CREATIVE)) {
                         ItemStack newMeal = event.getPlayer().getInventory().getItemInMainHand();
-                        newMeal.setAmount(newMeal.getAmount() - 1);
-                        event.getPlayer().getInventory().setItemInMainHand(newMeal);
+                        if ((newMeal.getAmount-1) == 0)
+                            event.getPlayer().getInventory().setItemInMainHand(null);
+                        else {
+                            newMeal.setAmount(newMeal.getAmount() - 1);
+                            event.getPlayer().getInventory().setItemInMainHand(newMeal);
+                        }
                     }
 
                 }


### PR DESCRIPTION
Using setAmount(stack.getAmount-1) will drop a TRAP error in console if u are set again item in player hand. This method is working good, but errors fears the most serverMakers.

exampleCode:
```java
@EventHandler
public void onRMB(PlayerInteractEvent e) {
	if (e.getPlayer().getInventory().getItemInMainHand() != null) {
		final ItemStack stack = e.getPlayer().getInventory().getItemInMainHand();

		stack.setAmount(stack.getAmount-1);

		e.getPlayer().getInventory().setItemInMainHand(stack);
	}
}
```

Error (Tested on 1.12.2)
```java
java.util.concurrent.ExecutionException: java.lang.AssertionError: TRAP
        at java.util.concurrent.FutureTask.report(Unknown Source) ~[?:1.8.0_271]
        at java.util.concurrent.FutureTask.get(Unknown Source) ~[?:1.8.0_271]
        at net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:47) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:850) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:423) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:774) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:666) ~[patched_1.12.2.jar:git-Paper-1618]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_271]
Caused by: java.lang.AssertionError: TRAP
        at net.minecraft.server.v1_12_R1.ItemStack.F(ItemStack.java:117) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.ItemStack.setCount(ItemStack.java:892) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.PlayerInteractManager.a(PlayerInteractManager.java:441) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.PlayerConnection.a(PlayerConnection.java:1064) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:26) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.PacketPlayInBlockPlace.a(PacketPlayInBlockPlace.java:5) ~[patched_1.12.2.jar:git-Paper-1618]
        at net.minecraft.server.v1_12_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:14) ~[patched_1.12.2.jar:git-Paper-1618]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:1.8.0_271]
        at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:1.8.0_271]
        at net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:46) ~[patched_1.12.2.jar:git-Paper-1618]
        ... 5 more

```

Methods to solve this issue:
1st: 
```java
@EventHandler
public void onRMB(PlayerInteractEvent e) {
	if (e.getPlayer().getInventory().getItemInMainHand() != null) {
		final ItemStack stack = e.getPlayer().getInventory().getItemInMainHand();

		stack.setAmount(stack.getAmount-1);
	}
}
```
2nd
```java
@EventHandler
public void onRMB(PlayerInteractEvent e) {
	if (e.getPlayer().getInventory().getItemInMainHand() != null) {
		final ItemStack stack = e.getPlayer().getInventory().getItemInMainHand();
			
		if (stack.getAmount()-1 == 0)
			e.getPlayer().getInventory().setItemInMainHand(null);
		else {
			stack.setAmount(stack.getAmount()-1);
			e.getPlayer().getInventory().setItemInMainHand(stack);
		}
	}
}
```

2nd method is better, cuz not in all cases the first method will work, in some cases you required to set item in player inventory slot again after making changes with item.